### PR TITLE
Fix function keys f13 to f24 displaying as Unknown in the UI

### DIFF
--- a/src/VKBindings.cpp
+++ b/src/VKBindings.cpp
@@ -509,6 +509,18 @@ const char* VKBindings::GetSpecialKeyName(const USHORT acVKCode)
     case VK_F10: return "F10";
     case VK_F11: return "F11";
     case VK_F12: return "F12";
+    case VK_F13: return "F13";
+    case VK_F14: return "F14";
+    case VK_F15: return "F15";
+    case VK_F16: return "F16";
+    case VK_F17: return "F17";
+    case VK_F18: return "F18";
+    case VK_F19: return "F19";
+    case VK_F20: return "F20";
+    case VK_F21: return "F21";
+    case VK_F22: return "F22";
+    case VK_F23: return "F23";
+    case VK_F24: return "F24";
     case VK_NUMLOCK: return "Num Lock";
     case VK_SCROLL: return "Scroll Lock";
     case VKBC_MWHEELUP: return "Mouse Wheel Up";


### PR DESCRIPTION
Fixes #764 

Function keys f13 to f24 work, but are displayed as "Unknown" in the UI.

Adding f13 to f24 to GetSpecialKeyName seems to work.

Tested by rebinding some keys to the above function keys as I don't have a keyboard with physical f13 to f24 keys.