### PR TITLE
Fix number conversion

### DIFF
--- a/src/reverse/LuaRED.h
+++ b/src/reverse/LuaRED.h
@@ -57,7 +57,10 @@ template <class T, FixedString REDName> struct LuaRED
         {
             if (aObject.get_type() == sol::type::number)
             {
-                result.value = apAllocator->New<T>(aObject.as<T>());
+                if (aObject.is<T>())
+                {
+                    result.value = apAllocator->New<T>(aObject.as<T>());
+                }
             }
             else if (IsLuaCData(aObject))
             {


### PR DESCRIPTION
Fixed incorrect behavior when float passed as int: it would lead to cryptic error "sol: runtime error: stack index -1, expected number, received number: not a numeric type or numeric string" and memory leaks.