### PR TITLE
Enable unity build also for C++

### DIFF
--- a/src/CET.cpp
+++ b/src/CET.cpp
@@ -5,7 +5,6 @@
 
 using namespace std::chrono_literals;
 
-static std::unique_ptr<CET> s_pInstance{nullptr};
 static bool s_isRunning{true};
 
 void CET::Initialize()

--- a/src/CET.h
+++ b/src/CET.h
@@ -42,4 +42,6 @@ private:
     LuaVM m_vm;
     Overlay m_overlay;
     CETTasks m_tasks;
+
+    inline static std::unique_ptr<CET> s_pInstance{nullptr};
 };

--- a/src/reverse/RTTIHelper.cpp
+++ b/src/reverse/RTTIHelper.cpp
@@ -14,9 +14,6 @@ namespace
 {
 constexpr bool s_cEnableOverloads = true;
 constexpr bool s_cLogAllOverloadVariants = true;
-constexpr bool s_cThrowLuaErrors = true;
-
-std::unique_ptr<RTTIHelper> s_pInstance{nullptr};
 
 using TCallScriptFunction = bool (*)(RED4ext::IFunction* apFunction, RED4ext::IScriptable* apContext, RED4ext::CStackFrame* apFrame, void* apResult, void* apResultType);
 

--- a/src/reverse/RTTIHelper.h
+++ b/src/reverse/RTTIHelper.h
@@ -83,4 +83,6 @@ private:
     RedFunctionMap m_extendedFunctions;
     LuaFunctionMap m_resolvedFunctions[2];
     LuaSandbox& m_sandbox;
+
+    inline static std::unique_ptr<RTTIHelper> s_pInstance{nullptr};
 };

--- a/src/reverse/RTTILocator.h
+++ b/src/reverse/RTTILocator.h
@@ -8,5 +8,5 @@ struct RTTILocator
 
 private:
     const RED4ext::CName m_name;
-    RED4ext::CBaseRTTIType* m_pRtti = nullptr;
+    mutable RED4ext::CBaseRTTIType* m_pRtti = nullptr;
 };

--- a/src/reverse/StrongReference.cpp
+++ b/src/reverse/StrongReference.cpp
@@ -5,8 +5,6 @@
 
 #include "CET.h"
 
-static RTTILocator s_sIScriptableType{RED4ext::FNV1a64("IScriptable")};
-
 StrongReference::StrongReference(const TiltedPhoques::Lockable<sol::state, std::recursive_mutex>::Ref& aView, RED4ext::Handle<RED4ext::IScriptable> aStrongHandle)
     : ClassType(aView, nullptr)
     , m_strongHandle(std::move(aStrongHandle))
@@ -22,12 +20,13 @@ StrongReference::StrongReference(
     : ClassType(aView, nullptr)
     , m_strongHandle(std::move(aStrongHandle))
 {
-    if (m_strongHandle)
-    {
-        auto const cpClass = reinterpret_cast<RED4ext::CClass*>(apStrongHandleType->GetInnerType());
+    if (!m_strongHandle)
+        return;
 
-        m_pType = cpClass->IsA(s_sIScriptableType) ? m_strongHandle->GetType() : m_strongHandle->GetNativeType();
-    }
+    const auto cpClass = reinterpret_cast<RED4ext::CClass*>(apStrongHandleType->GetInnerType());
+
+    thread_local static RTTILocator sIScriptableType{RED4ext::FNV1a64("IScriptable")};
+    m_pType = cpClass->IsA(sIScriptableType) ? m_strongHandle->GetType() : m_strongHandle->GetNativeType();
 }
 
 StrongReference::~StrongReference()

--- a/src/scripting/FunctionOverride.cpp
+++ b/src/scripting/FunctionOverride.cpp
@@ -18,7 +18,6 @@ using TCallScriptFunction = bool (*)(RED4ext::IFunction* apFunction, RED4ext::IS
 
 TRunPureScriptFunction RealRunPureScriptFunction = nullptr;
 TCreateFunction RealCreateFunction = nullptr;
-RED4ext::RelocFunc<TCallScriptFunction> CallScriptFunction(RED4ext::Addresses::CBaseFunction_InternalExecute);
 
 constexpr size_t s_cMaxFunctionSize = std::max({sizeof(RED4ext::CClassFunction), sizeof(RED4ext::CClassStaticFunction), sizeof(RED4ext::CGlobalFunction)});
 
@@ -347,7 +346,7 @@ void FunctionOverride::HandleOverridenFunction(RED4ext::IScriptable* apContext, 
 
     lock.unlock();
 
-    CallScriptFunction(pRealFunction, apContext, apFrame, apOut, a4);
+    RED4ext::RelocFunc<TCallScriptFunction>{RED4ext::Addresses::CBaseFunction_InternalExecute}(pRealFunction, apContext, apFrame, apOut, a4);
 }
 
 bool FunctionOverride::ExecuteChain(
@@ -418,7 +417,8 @@ bool FunctionOverride::ExecuteChain(
             apFrame->code = apCode;
             apFrame->currentParam = aParam;
 
-            realRetValue = CallScriptFunction(pRealFunction, apContext, apFrame, apResult->value, apResult->type);
+            realRetValue =
+                RED4ext::RelocFunc<TCallScriptFunction>{RED4ext::Addresses::CBaseFunction_InternalExecute}(pRealFunction, apContext, apFrame, apResult->value, apResult->type);
         }
     }
 

--- a/src/scripting/Scripting.cpp
+++ b/src/scripting/Scripting.cpp
@@ -27,8 +27,6 @@
 #include <RED4ext/Dump/Reflection.hpp>
 #endif
 
-static constexpr bool s_cThrowLuaErrors = true;
-
 static RTTILocator s_stringType{RED4ext::FNV1a64("String")};
 static RTTILocator s_resRefType{RED4ext::FNV1a64("redResourceReferenceScriptToken")};
 

--- a/src/scripting/Scripting.h
+++ b/src/scripting/Scripting.h
@@ -5,6 +5,8 @@
 #include "reverse/RTTIMapper.h"
 #include "reverse/SingletonReference.h"
 
+inline static constexpr bool s_cThrowLuaErrors = true;
+
 struct D3D12;
 
 struct Scripting

--- a/xmake.lua
+++ b/xmake.lua
@@ -6,6 +6,7 @@ set_arch("x64")
 add_rules("mode.debug","mode.releasedbg", "mode.release")
 add_rules("plugin.vsxmake.autoupdate")
 add_rules("c.unity_build")
+add_rules("c++.unity_build")
 
 add_cxflags("/bigobj", "/MP")
 add_defines("RED4EXT_STATIC_LIB", "UNICODE", "_UNICODE", "_CRT_SECURE_NO_WARNINGS")


### PR DESCRIPTION
We had enabled unity builds, but only for C files. This enables it for C++ also, builds should be faster.