### PR TITLE
Make TweakDBEditor cache rebuilding async

### DIFF
--- a/src/overlay/widgets/TweakDBEditor.h
+++ b/src/overlay/widgets/TweakDBEditor.h
@@ -11,6 +11,8 @@ struct TweakDBEditor : Widget
 protected:
     void OnUpdate() override;
 
+    void RebuildCache();
+
     void RefreshAll();
     void RefreshRecords();
     void RefreshFlats();
@@ -124,6 +126,8 @@ private:
 
     LuaVM& m_vm;
     bool m_initialized = false;
+    bool m_rebuildingCache = false;
+    std::future<void> m_rebuildCacheFuture;
     int32_t m_flatGroupNameDepth = 1;
     TiltedPhoques::Vector<CachedFlatGroup> m_cachedFlatGroups;
     TiltedPhoques::Vector<CachedRecordGroup> m_cachedRecords;

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -56,6 +56,7 @@
 #include <execution>
 #include <filesystem>
 #include <fstream>
+#include <future>
 #include <iostream>
 #include <memory>
 #include <mutex>


### PR DESCRIPTION
Cache rebuilding is quite slow, mainly in Debug build of CET. This causes quite a big of a lag when user opens TweakDBEditor widget for the first time. Same would happen if user hit `Refresh all` under `Advanced` tab in the widget. 

This PR delegates cache rebuilds to another thread.