### PR TITLE
Fix typo in TweakDBEditor initialization causing it to "finish" sooner

### DIFF
--- a/src/overlay/widgets/TweakDBEditor.cpp
+++ b/src/overlay/widgets/TweakDBEditor.cpp
@@ -213,8 +213,6 @@ void TweakDBEditor::RefreshAll()
 {
     RefreshRecords();
     RefreshFlats();
-
-    m_initialized = true;
 }
 
 void TweakDBEditor::RefreshRecords()


### PR DESCRIPTION
Accidentally left in... This caused cache rebuild to early-report that initialization finished, leading to possibility of race conditions.