### PR TITLE
remove offset from gameIGameSystem constructor call

### DIFF
--- a/src/reverse/RTTIExtender.cpp
+++ b/src/reverse/RTTIExtender.cpp
@@ -118,7 +118,7 @@ struct gameIGameSystem : IUpdatableSystem
     {
         // expected: 2, index: 0
         using TFunc = void (*)(void*);
-        static GameCall<TFunc> func(CyberEngineTweaks::Addresses::gameIGameSystem_Constructor, -6);
+        static GameCall<TFunc> func(CyberEngineTweaks::Addresses::gameIGameSystem_Constructor);
         func(apAddress); // gameIGameSystem::ctor()
     }
 


### PR DESCRIPTION
The offset leads to the function before the constructor being partially executed, leading to an access violation