### PR TITLE
uvfs support for CET with MO2 

### DIFF
--- a/src/CET.cpp
+++ b/src/CET.cpp
@@ -74,7 +74,6 @@ CET::CET()
     , m_vm(m_paths, m_bindings, m_d3d12)
     , m_overlay(m_bindings, m_options, m_persistentState, m_vm)
 {
-    m_vm.Initialize();
 }
 
 CET::~CET()

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -286,35 +286,6 @@ std::filesystem::path GetAbsolutePath(std::filesystem::path aFilePath, const std
     return aFilePath;
 }
 
-std::filesystem::path GetLuaPath(const std::string& acFilePath, const std::filesystem::path& acRootPath, const bool acAllowNonExisting)
-{
-    return GetLuaPath(UTF8ToUTF16(acFilePath), acRootPath, acAllowNonExisting);
-}
-
-std::filesystem::path GetLuaPath(std::filesystem::path aFilePath, const std::filesystem::path& acRootPath, const bool acAllowNonExisting)
-{
-    assert(!aFilePath.empty());
-    assert(!aFilePath.is_absolute());
-
-    if (aFilePath.empty() || aFilePath.is_absolute())
-        return {};
-
-    aFilePath.make_preferred();
-
-    if (aFilePath.native().starts_with(L"..\\"))
-        return {};
-
-    aFilePath = GetAbsolutePath(aFilePath, acRootPath, acAllowNonExisting, false);
-    if (aFilePath.empty())
-        return {};
-
-    const auto relativeFilePathToRoot = relative(aFilePath, acRootPath);
-    if (relativeFilePathToRoot.native().starts_with(L"..\\") || relativeFilePathToRoot.native().find(L"\\..\\") != std::wstring::npos)
-        return {};
-
-    return relative(aFilePath, std::filesystem::current_path());
-}
-
 std::vector<char> ReadWholeBinaryFile(const std::filesystem::path& acpPath)
 {
     if (acpPath.empty() || !exists(acpPath))

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "scripting/LuaSandbox.h"
+
 #include <overlay/widgets/Widget.h>
 
 void ltrim(std::string& s);
@@ -52,9 +54,6 @@ TChangedCBResult UnsavedChangesPopup(
 GetAbsolutePath(const std::string& acFilePath, const std::filesystem::path& acRootPath, const bool acAllowNonExisting, const bool acAllowSymlink = true);
 [[nodiscard]] std::filesystem::path
 GetAbsolutePath(std::filesystem::path aFilePath, const std::filesystem::path& acRootPath, const bool acAllowNonExisting, const bool acAllowSymlink = true);
-
-[[nodiscard]] std::filesystem::path GetLuaPath(const std::string& acFilePath, const std::filesystem::path& acRootPath, const bool acAllowNonExisting);
-[[nodiscard]] std::filesystem::path GetLuaPath(std::filesystem::path aFilePath, const std::filesystem::path& acRootPath, const bool acAllowNonExisting);
 
 [[nodiscard]] std::vector<char> ReadWholeBinaryFile(const std::filesystem::path& acpPath);
 [[nodiscard]] std::string ReadWholeTextFile(const std::filesystem::path& acpPath);

--- a/src/scripting/LuaSandbox.h
+++ b/src/scripting/LuaSandbox.h
@@ -28,6 +28,12 @@ struct LuaSandbox
 
     sol::table& GetGlobals();
 
+    const bool GetIsLaunchedThroughMO2() const { return m_isLaunchedThroughMO2; }
+    [[nodiscard]] std::filesystem::path
+    GetLuaPath(const std::string& acFilePath, const std::filesystem::path& acRootPath, const bool acAllowNonExisting) const;
+    [[nodiscard]] std::filesystem::path
+    GetLuaPath(std::filesystem::path aFilePath, const std::filesystem::path& acRootPath, const bool acAllowNonExisting) const;
+
 private:
     void InitializeExtraLibsForSandbox(Sandbox& aSandbox, const sol::state& acpState) const;
     void InitializeDBForSandbox(Sandbox& aSandbox, const sol::state& acpState);
@@ -43,4 +49,5 @@ private:
     TiltedPhoques::Map<std::string, sol::object> m_modules{};
 
     bool m_imguiAvailable{false};
+    bool m_isLaunchedThroughMO2{false};
 };

--- a/src/scripting/LuaVM_Hooks.cpp
+++ b/src/scripting/LuaVM_Hooks.cpp
@@ -311,6 +311,9 @@ void LuaVM::HookTDBIDToStringDEBUG(RED4ext::IScriptable*, RED4ext::CStackFrame* 
 
 void LuaVM::HookTranslateBytecode(uintptr_t aBinder, uintptr_t aData)
 {
+    // Delay our lua hook until later, to ensure that Mod Organizer's VFS is hooked up.
+    CET::Get().GetVM().Initialize();
+
     s_vm->m_realTranslateBytecode(aBinder, aData);
     s_vm->PostInitializeScripting();
 }

--- a/src/scripting/ScriptContext.cpp
+++ b/src/scripting/ScriptContext.cpp
@@ -169,7 +169,7 @@ ScriptContext::ScriptContext(LuaSandbox& aLuaSandbox, const std::filesystem::pat
         const auto previousCurrentPath = std::filesystem::current_path();
         current_path(sb.GetRootPath());
 
-        const auto path = GetLuaPath(L"init.lua", acPath, false);
+        const auto path = m_sandbox.GetLuaPath(L"init.lua", acPath, false);
 
         const auto result = sb.ExecuteFile(UTF16ToUTF8(path.native()));
 

--- a/src/scripting/Scripting.h
+++ b/src/scripting/Scripting.h
@@ -39,6 +39,7 @@ struct Scripting
 
     LuaSandbox& GetSandbox();
     LockedState GetLockedState() const noexcept;
+    const std::filesystem::path& GameRoot() const { return m_paths.GameRoot(); }
 
     static size_t Size(RED4ext::CBaseRTTIType* apRttiType);
     static sol::object ToLua(LockedState& aState, RED4ext::CStackType& aResult);


### PR DESCRIPTION
# The problem

When launching the game through Mod Organizer 2, CET mods don't work
That is because 
- (1) the luaVM is started too soon (before MO2s virtual file system has started)
- and (2) because MO2 overlays 3 different directories in its VFS: the base game dir, the virtualized mod dir, and the "overwrite" dir where runtime-created files are stored.

Any mod that creates files at runtime (that is ALL CET mods since the sandbox db gets created at runtime) will fail since the "overwrite" directory escapes the mod sandbox.

# This PR

This PR does two things:
1. It delays the luaVM init slightly so that CET mods get detected after UVFS did its thing
2. More problematically, it allows lua paths outside the mod sandbox under certain conditions:
  - when the game is launched through MO2 (we detect `usvfs_x64.dll`)
  - and when the lua path originates from MO2s "overwrite" directory (we detect this by comparing relative paths)

Since `GetLuaPath` does more checks now, I needed to move it out of utils into sandbox.
This also incurred pulling the sandbox into more lambdas.

## Pros and Cons
### Pros: 
- It would allow running CET mods from a popular mod manager (MO2)

### Cons: 
- We give up some sandbox security under certain conditions. Other script extenders (like Bethesda Script Extenders) seem to find this acceptable.