### PR TITLE
fix: relative file paths for uvfs

### DIFF
--- a/src/scripting/LuaSandbox.cpp
+++ b/src/scripting/LuaSandbox.cpp
@@ -507,8 +507,7 @@ void LuaSandbox::InitializeIOForSandbox(Sandbox& aSandbox, const sol::state& acp
         for (const auto& entry : std::filesystem::directory_iterator(path))
         {
             sol::table item(stateView, sol::create);
-            item["relativePath"] = UTF16ToUTF8(Relative(entry.path(), path).native());
-            item["name"] = UTF16ToUTF8(entry.path().filename().native());
+            item["name"] = UTF16ToUTF8(Relative(entry.path(), path).native());
             item["type"] = entry.is_directory() ? "directory" : "file";
             res[index++] = item;
         }

--- a/src/scripting/LuaSandbox.h
+++ b/src/scripting/LuaSandbox.h
@@ -29,6 +29,8 @@ struct LuaSandbox
     sol::table& GetGlobals();
 
     const bool GetIsLaunchedThroughMO2() const { return m_isLaunchedThroughMO2; }
+    [[nodiscard]] std::filesystem::path 
+    Relative(const std::filesystem::path& acFilePath, const std::filesystem::path& acRootPath) const;
     [[nodiscard]] std::filesystem::path
     GetLuaPath(const std::string& acFilePath, const std::filesystem::path& acRootPath, const bool acAllowNonExisting) const;
     [[nodiscard]] std::filesystem::path


### PR DESCRIPTION
One more uvfs fix for relative file paths.

PR for @seberoths and @zashs suggestions.
~~- api addition for `dir()`: add relativePath property~~
- internal relative() resolve in luasandbox for uvfs
- restore original relativePath check for sandbox

closes #890 