### PR TITLE
Fix integer sizing in Enum

### DIFF
--- a/src/reverse/Converter.h
+++ b/src/reverse/Converter.h
@@ -156,7 +156,7 @@ struct EnumConverter : LuaRED<Enum, "Enum">
         else if (aObject.get_type() == sol::type::number) // Enum from number cast
         {
             auto* enumType = static_cast<RED4ext::CEnum*>(apType->type);
-            const Enum en(enumType, aObject.as<uint32_t>());
+            const Enum en(enumType, aObject.as<int32_t>());
             en.Set(*apType);
         }
         else if (aObject.get_type() == sol::type::string) // Enum from string cast

--- a/src/reverse/Enum.h
+++ b/src/reverse/Enum.h
@@ -1,25 +1,43 @@
 #pragma once
 
+union EnumValue
+{
+    int8_t int8;
+    int16_t int16;
+    int32_t int32;
+    int64_t int64;
+};
+
+// Represents a specific value of an enum
+// Always assumes enums may only be 1, 2, 4, or 8 bytes wide
 struct Enum
 {
+    // Creates an Enum from its type description and a value's name
     Enum(const RED4ext::CEnum*, const std::string& acValue);
-    Enum(const RED4ext::CEnum*, uint32_t aValue);
+    // Creates an Enum from its type description and a value. If the provided value does not appear to be valid, 0 is used instead
+    Enum(const RED4ext::CEnum*, int32_t aValue);
+    // Creates an Enum from a stack value with type RED4ext::CEnum*. value is assumed to be an int64_t
     Enum(const RED4ext::CStackType& acStackType);
+    // Creates an Enum from its type name and a value's name
     Enum(const std::string& acTypeName, const std::string& acValue);
-    Enum(const std::string& acTypeName, uint32_t aValue);
+    // Creates an Enum from its type name and a value. If the provided value does not appear to be valid, 0 is used instead
+    Enum(const std::string& acTypeName, int32_t aValue);
 
+    // Sets m_value based on acStackType's value
     void Get(const RED4ext::CStackType& acStackType) noexcept;
+    // Sets acStackType's type and value to match this instance. Always allocates new memory for the value. Does not free memory if a value is already present
     void Set(RED4ext::CStackType& acStackType, TiltedPhoques::Allocator* apAllocator) const noexcept;
+    // Sets acStackType's value based on m_value
     void Set(RED4ext::CStackType& acStackType) const noexcept;
 
-    // Returns the enum value by name
+    // Returns the name of the current value
     std::string GetValueName() const;
 
-    // Sets value by name in the enum list
+    // Sets value by name. If the provided name does not appear in the list of names, the value is not set
     void SetValueByName(const std::string& acValue);
 
-    // Sets by value verified against enum list
-    void SetValueSafe(uint64_t aValue);
+    // Sets by value verified against enum list. If the provided value does not appear to be valid, the value is not set
+    void SetValueSafe(int64_t aValue);
 
     std::string ToString() const;
 
@@ -27,10 +45,12 @@ struct Enum
 
     const RED4ext::CEnum* GetType() const;
     const void* GetValuePtr() const;
+    // Returns m_value as an int64_t, casting with sign extension if needed
+    int64_t GetValue() const;
 
 protected:
     friend struct Scripting;
 
     const RED4ext::CEnum* m_cpType{nullptr};
-    uint64_t m_value{0};
+    EnumValue m_value{0};
 };

--- a/src/scripting/Scripting.cpp
+++ b/src/scripting/Scripting.cpp
@@ -214,17 +214,27 @@ void Scripting::PostInitializeScripting()
         [](const sol::object&) -> bool { return false; });
 
     globals.new_usertype<Enum>(
-        "Enum", sol::constructors<Enum(const std::string&, const std::string&), Enum(const std::string&, uint32_t), Enum(const Enum&)>(), sol::meta_function::to_string,
+        "Enum", sol::constructors<Enum(const std::string&, const std::string&), Enum(const std::string&, int32_t), Enum(const Enum&)>(), sol::meta_function::to_string,
         &Enum::ToString, sol::meta_function::equal_to, &Enum::operator==, "value", sol::property(&Enum::GetValueName, &Enum::SetValueByName));
 
     globals["EnumInt"] = [this](Enum& aEnum) -> sol::object
     {
-        static RTTILocator s_uint64Type{RED4ext::FNV1a64("Uint64")};
+        static RTTILocator s_int8Type{RED4ext::FNV1a64("Int8")};
+        static RTTILocator s_int16Type{RED4ext::FNV1a64("Int16")};
+        static RTTILocator s_int32Type{RED4ext::FNV1a64("Int32")};
+        static RTTILocator s_int64Type{RED4ext::FNV1a64("Int64")};
 
         auto lockedState = m_lua.Lock();
 
         RED4ext::CStackType stackType;
-        stackType.type = s_uint64Type;
+        switch (aEnum.m_cpType->GetSize())
+        {
+        case sizeof(int8_t): stackType.type = s_int8Type; break;
+        case sizeof(int16_t): stackType.type = s_int16Type; break;
+        case sizeof(int32_t): stackType.type = s_int32Type; break;
+        case sizeof(int64_t): stackType.type = s_int64Type; break;
+        }
+
         stackType.value = &aEnum.m_value;
 
         return Converter::ToLua(stackType, lockedState);


### PR DESCRIPTION
Fixes https://github.com/maximegmd/CyberEngineTweaks/issues/888.

Pretty straightforward changes - mainly just converted `Enum.m_value` to a union and wrote conversions where needed. Important bits:

- Two constructors still only take `int32_t` which theoretically isn't wide enough, but they're currently only called using numbers from Lua which aren't precise enough either. Could be fixed, but a cursory scan didn't turn up anything currently in the game that's large enough to need more than an int32, so I didn't worry about it
- I went ahead and switched to all signed numbers. I haven't seen anything that seems unsigned, but there's quite a lot of obviously negative numbers, so this seems reasonable to me
- I modified the `EnumInt` function exposed to Lua to return a correctly sized int. This isn't strictly necessary and it could just be an Int64 if that's preferred
- For testing I created enums for every size that each had values of 0, 1, 2, -1, -2, and the max and min values for the type. Everything seemed to work correctly, except of course that Lua can't represent max int64_t with its native numbers
- I made sure all the `Enum` constructors work correctly from Lua

Let me know if there's any changes I need to make or other information you need!