### PR TITLE
Fix "Disable VSync" settings description

### DIFF
--- a/src/overlay/widgets/Settings.cpp
+++ b/src/overlay/widgets/Settings.cpp
@@ -80,7 +80,7 @@ void Settings::OnUpdate()
                     patchesSettings.DisableBoundaryTeleport);
                 UpdateAndDrawSetting("Disable V-Sync (Windows 7 only)", "Disables VSync on Windows 7 to bypass the 60 FPS limit (requires restart to take effect).", m_patches.DisableWin7Vsync, patchesSettings.DisableWin7Vsync);
                 UpdateAndDrawSetting(
-                    "Fix Minimap Flicker", "Fixes the flickering Minimap (requires restart to take effect).", m_patches.MinimapFlicker,
+                    "Fix Minimap Flicker", "Fixes Minimap flicker caused by some mods (requires restart to take effect).", m_patches.MinimapFlicker,
                     patchesSettings.MinimapFlicker);
 
                 ImGui::EndTable();

--- a/src/overlay/widgets/Settings.cpp
+++ b/src/overlay/widgets/Settings.cpp
@@ -78,9 +78,9 @@ void Settings::OnUpdate()
                 UpdateAndDrawSetting(
                     "Disable Boundary Teleport", "Allows players to access out-of-bounds locations (requires restart to take effect).", m_patches.DisableBoundaryTeleport,
                     patchesSettings.DisableBoundaryTeleport);
-                UpdateAndDrawSetting("Disable V-Sync (Windows 7 only)", " (requires restart to take effect).", m_patches.DisableWin7Vsync, patchesSettings.DisableWin7Vsync);
+                UpdateAndDrawSetting("Disable V-Sync (Windows 7 only)", "Disables VSync on Windows 7 to bypass the 60 FPS limit (requires restart to take effect).", m_patches.DisableWin7Vsync, patchesSettings.DisableWin7Vsync);
                 UpdateAndDrawSetting(
-                    "Fix Minimap Flicker", "Disables VSync on Windows 7 to bypass the 60 FPS limit (requires restart to take effect).", m_patches.MinimapFlicker,
+                    "Fix Minimap Flicker", "Fixes the flickering Minimap (requires restart to take effect).", m_patches.MinimapFlicker,
                     patchesSettings.MinimapFlicker);
 
                 ImGui::EndTable();


### PR DESCRIPTION
 I fixed the description of the Disable V-sync setting because it was seemingly copy-pasted to the wrong Fix Minimap Flicker setting. I modified that settings description too but am not quite sure what to write in there because I never actually experienced the issue myself. 