### PR TITLE
Improved readability of the console window, especially errors

### DIFF
--- a/src/overlay/widgets/LogWindow.cpp
+++ b/src/overlay/widgets/LogWindow.cpp
@@ -29,6 +29,7 @@ void LogWindow::Draw(const ImVec2& size)
     const auto& style = ImGui::GetStyle();
 
     const auto frameId = ImGui::GetID(("##" + m_loggerName).c_str());
+    ImGui::PushStyleColor(ImGuiCol_FrameBg, ImVec4(0.0f, 0, 0, 0.5f));
     if (ImGui::BeginChildFrame(frameId, size, ImGuiWindowFlags_HorizontalScrollbar))
     {
         std::lock_guard _{m_lock};
@@ -61,7 +62,7 @@ void LogWindow::Draw(const ImVec2& size)
                 case spdlog::level::level_enum::warn: ImGui::PushStyleColor(ImGuiCol_Text, ImVec4{1.0f, 1.0f, 0.0f, 1.0f}); break;
 
                 case spdlog::level::level_enum::err:
-                case spdlog::level::level_enum::critical: ImGui::PushStyleColor(ImGuiCol_Text, ImVec4{1.0f, 0.0f, 0.0f, 1.0f}); break;
+                case spdlog::level::level_enum::critical: ImGui::PushStyleColor(ImGuiCol_Text, ImVec4{1.0f, 0.1f, 0.2f, 1.0f}); break;
 
                 case spdlog::level::level_enum::info:
                 default: ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyleColorVec4(ImGuiCol_Text));
@@ -95,6 +96,7 @@ void LogWindow::Draw(const ImVec2& size)
         }
     }
     ImGui::EndChildFrame();
+    ImGui::PopStyleColor(1); // pop ImGuiCol_FrameBg
 }
 
 void LogWindow::Log(const std::string& acpText)


### PR DESCRIPTION
Currently red on blue errors are almost unreadable in the console. This PR changes the background of the console content to semi-transparent black and changes the the error color to a slightly brighter shade of red.
Before:
![image](https://github.com/maximegmd/CyberEngineTweaks/assets/5261364/b7549063-9e15-4e0c-8075-75473bd4819c)

After:
![image](https://github.com/maximegmd/CyberEngineTweaks/assets/5261364/6584ea1b-f7ec-494b-838b-96d5fc020b41)
