### PR TITLE
Fix overlay rendering issues that lead to crashing when other overlays are present

### DIFF
--- a/src/d3d12/D3D12.cpp
+++ b/src/d3d12/D3D12.cpp
@@ -9,17 +9,28 @@
 
 void D3D12::SetTrapInputInImGui(const bool acEnabled)
 {
+    // Must have an out-condition to this otherwise infinite loop
+    static int constexpr maxCursorDepth = 8;
+    int showCursorTries = 0;
     int showCursorState;
     if (acEnabled)
         do
         {
             showCursorState = ShowCursor(TRUE);
-        } while (showCursorState < 0);
+        } while (showCursorState < 0 && showCursorTries++ < maxCursorDepth);
     else
         do
         {
             showCursorState = ShowCursor(FALSE);
-        } while (showCursorState >= 0);
+        } while (showCursorState >= 0 && showCursorTries++ < maxCursorDepth);
+
+    // Turn off software cursor
+    if (showCursorTries < maxCursorDepth || acEnabled == false)
+        ImGui::GetIO().MouseDrawCursor = false;
+
+    // Enable software cursor as fallback if necessary
+    else
+        ImGui::GetIO().MouseDrawCursor = acEnabled;
 
     m_trapInputInImGui = acEnabled;
 }

--- a/src/d3d12/D3D12.h
+++ b/src/d3d12/D3D12.h
@@ -35,6 +35,7 @@ protected:
     struct FrameContext
     {
         Microsoft::WRL::ComPtr<ID3D12CommandAllocator> CommandAllocator;
+        Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList> CommandList{};
         Microsoft::WRL::ComPtr<ID3D12Resource> BackBuffer;
         D3D12_CPU_DESCRIPTOR_HANDLE MainRenderTargetDescriptor{0};
     };
@@ -62,7 +63,6 @@ private:
     Microsoft::WRL::ComPtr<ID3D12Device> m_pd3d12Device{};
     Microsoft::WRL::ComPtr<ID3D12DescriptorHeap> m_pd3dRtvDescHeap{};
     Microsoft::WRL::ComPtr<ID3D12DescriptorHeap> m_pd3dSrvDescHeap{};
-    Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList> m_pd3dCommandList{};
 
     // borrowed resources from game, do not manipulate reference counts on these!
     Microsoft::WRL::ComPtr<IDXGISwapChain4> m_pdxgiSwapChain{nullptr};

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -70,7 +70,8 @@ static void Shutdown()
 
 BOOL APIENTRY DllMain(HMODULE mod, DWORD ul_reason_for_call, LPVOID)
 {
-    DisableThreadLibraryCalls(mod);
+    // Not safe to do this, the DLL uses thread_local storage
+    //DisableThreadLibraryCalls(mod);
 
     switch (ul_reason_for_call)
     {

--- a/src/window/window.cpp
+++ b/src/window/window.cpp
@@ -14,9 +14,9 @@ static BOOL CALLBACK EnumWindowsProcCP77(HWND ahWnd, LPARAM alParam)
     GetWindowThreadProcessId(ahWnd, &lpdwProcessId);
     if (lpdwProcessId == GetCurrentProcessId())
     {
-        TCHAR name[512] = {0};
-        GetWindowText(ahWnd, name, 511);
-        if (_tcscmp(TEXT("Cyberpunk 2077 (C) 2020 by CD Projekt RED"), name) == 0)
+        wchar_t name[512] = {0};
+        RealGetWindowClassW(ahWnd,name,511);
+        if (wcscmp (L"W2ViewportClass", name) == 0)
         {
             *reinterpret_cast<HWND*>(alParam) = ahWnd;
             return FALSE;
@@ -32,8 +32,11 @@ LRESULT APIENTRY Window::WndProc(HWND ahWnd, UINT auMsg, WPARAM awParam, LPARAM 
         if (auMsg == WM_WINDOWPOSCHANGED)
         {
             const auto* wp = reinterpret_cast<WINDOWPOS*>(alParam);
-            s_pWindow->m_wndPos = {wp->x, wp->y};
-            s_pWindow->m_wndSize = {wp->cx, wp->cy};
+
+            if ((wp->flags & SWP_NOMOVE) == 0)
+                s_pWindow->m_wndPos = {wp->x, wp->y};
+            if ((wp->flags & SWP_NOSIZE) == 0)
+                s_pWindow->m_wndSize = {wp->cx, wp->cy};
 
             RECT cr;
             GetClientRect(ahWnd, &cr);


### PR DESCRIPTION
I have been getting several reports from Special K users of crashes when using this mod, and finally had some time to investigate.

Primary issues found:

 1. Code to show/hide the hardware cursor does not handle pathological case where something is preventing the cursor's state from changing -- infinite loop.
 2. DisableThreadLibraryCalls (...) used in a DLL that uses MSVCRT managed thread_local storage.
 3. A single command allocator/list was being used for all frame contexts, despite creating per-context allocators.
 4. The game's window title was being used to find the main window, but this is highly volatile; use window class name instead.