### PR TITLE
Fix ImGui spam of ShowCursor/HideCursor

### DIFF
--- a/src/d3d12/D3D12.cpp
+++ b/src/d3d12/D3D12.cpp
@@ -9,28 +9,11 @@
 
 void D3D12::SetTrapInputInImGui(const bool acEnabled)
 {
-    // Must have an out-condition to this otherwise infinite loop
-    static int constexpr maxCursorDepth = 8;
-    int showCursorTries = 0;
-    int showCursorState;
-    if (acEnabled)
-        do
-        {
-            showCursorState = ShowCursor(TRUE);
-        } while (showCursorState < 0 && showCursorTries++ < maxCursorDepth);
-    else
-        do
-        {
-            showCursorState = ShowCursor(FALSE);
-        } while (showCursorState >= 0 && showCursorTries++ < maxCursorDepth);
+    static const RED4ext::CName cReason = "ImGui";
+    static RED4ext::UniversalRelocFunc<void (*)(RED4ext::CBaseEngine::UnkD0* apThis, RED4ext::CName aReason, bool aShow)>
+        forceCursor(CyberEngineTweaks::AddressHashes::InputSystemWin32Base_ForceCursor);
 
-    // Turn off software cursor
-    if (showCursorTries < maxCursorDepth || acEnabled == false)
-        ImGui::GetIO().MouseDrawCursor = false;
-
-    // Enable software cursor as fallback if necessary
-    else
-        ImGui::GetIO().MouseDrawCursor = acEnabled;
+    forceCursor(RED4ext::CGameEngine::Get()->unkD0, cReason, acEnabled);
 
     m_trapInputInImGui = acEnabled;
 }

--- a/src/d3d12/D3D12_Functions.cpp
+++ b/src/d3d12/D3D12_Functions.cpp
@@ -81,7 +81,7 @@ bool D3D12::Initialize()
 
     D3D12_DESCRIPTOR_HEAP_DESC srvdesc = {};
     srvdesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
-    srvdesc.NumDescriptors = buffersCounts;
+    srvdesc.NumDescriptors = 200; // Same number as is used in scripting/Texture
     srvdesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
     if (FAILED(m_pd3d12Device->CreateDescriptorHeap(&srvdesc, IID_PPV_ARGS(&m_pd3dSrvDescHeap))))
     {
@@ -312,6 +312,8 @@ bool D3D12::InitializeImGui(size_t aBuffersCounts)
 
     ImGui::GetStyle() = m_styleReference;
     ImGui::GetStyle().ScaleAllSizes(scaleFromReference);
+
+    ImGui::GetIO().ConfigFlags |= ImGuiConfigFlags_NoMouseCursorChange; // Do not modify cursor from ImGui backend
 
     if (!ImGui_ImplWin32_Init(m_window.GetWindow()))
     {

--- a/src/overlay/Overlay.h
+++ b/src/overlay/Overlay.h
@@ -7,8 +7,6 @@
 #include "widgets/GameLog.h"
 #include "widgets/ImGuiDebug.h"
 
-using TClipToCenter = HWND(RED4ext::CGameEngine::UnkD0*);
-
 struct Overlay
 {
     Overlay(VKBindings& aBindings, Options& aOptions, PersistentState& aPersistentState, LuaVM& aVm);
@@ -27,11 +25,6 @@ struct Overlay
 
     void Update();
 
-protected:
-    void Hook();
-
-    static BOOL ClipToCenter(RED4ext::CGameEngine::UnkD0* apThis);
-
 private:
     void DrawToolbar();
 
@@ -41,8 +34,6 @@ private:
     TweakDBEditor m_tweakDBEditor;
     GameLog m_gameLog;
     ImGuiDebug m_imguiDebug;
-
-    TClipToCenter* m_realClipToCenter{nullptr};
 
     std::atomic_bool m_enabled{false};
     std::atomic_bool m_toggled{false};

--- a/src/reverse/Addresses.h
+++ b/src/reverse/Addresses.h
@@ -59,8 +59,8 @@ constexpr uint32_t CScript_TweakDBLoad = 3602585178UL;           // game::data::
 constexpr uint32_t CShutdownState_OnTick = 4069332669UL; // red::GameAppShutdownState::OnTick
 #pragma endregion
 
-#pragma region CWinapi
-constexpr uint32_t CWinapi_ClipToCenter = 261693736UL; // input::InputSystemWin32Base::Update
+#pragma region InputSystemWin32Base
+constexpr uint32_t InputSystemWin32Base_ForceCursor = 2130646213UL; // input::InputSystemWin32Base::ForceCursor
 #pragma endregion
 
 #pragma region gameIGameSystem


### PR DESCRIPTION
Also makes sure that we actually have 200 descriptors for texture, we allocated only 3 (ImGui really needs only 1 though per viewport, we have one in main) but allowed up to 200.