### PR TITLE
Add TrapInput script function.

### DIFF
--- a/src/d3d12/D3D12.cpp
+++ b/src/d3d12/D3D12.cpp
@@ -20,8 +20,31 @@ void D3D12::SetTrapInputInImGui(const bool acEnabled)
 
 void D3D12::DelayedSetTrapInputInImGui(const bool acEnabled)
 {
-    m_delayedTrapInputState = acEnabled;
-    m_delayedTrapInput = true;
+    if (acEnabled)
+    {
+        // Trap input if it's the first request.
+        if (m_trapInputStack == 0)
+        {
+            m_delayedTrapInputState = acEnabled;
+            m_delayedTrapInput = true;
+        }
+
+        ++m_trapInputStack;
+    }
+    else
+    {
+        if (m_trapInputStack > 0)
+        {
+            --m_trapInputStack;
+
+            // Disable when the last request is removed.
+            if (m_trapInputStack == 0)
+            {
+                m_delayedTrapInputState = acEnabled;
+                m_delayedTrapInput = true;
+            }
+        }
+    }
 }
 
 LRESULT D3D12::OnWndProc(HWND ahWnd, UINT auMsg, WPARAM awParam, LPARAM alParam) const

--- a/src/d3d12/D3D12.h
+++ b/src/d3d12/D3D12.h
@@ -81,4 +81,5 @@ private:
     std::array<ImDrawData, 3> m_imguiDrawDataBuffers;
     std::atomic_bool m_delayedTrapInput{false};
     std::atomic_bool m_delayedTrapInputState{false};
+    std::atomic_uint32_t m_trapInputStack{0};
 };

--- a/src/scripting/Scripting.cpp
+++ b/src/scripting/Scripting.cpp
@@ -472,6 +472,12 @@ void Scripting::PostInitializeScripting()
         logger->info("Dumped {} types", count);
     };
 
+    globals["TrapInput"] = [](bool bEnabled)
+    {
+        auto& d3d12 = CET::Get().GetD3D12();
+        d3d12.DelayedSetTrapInputInImGui(bEnabled);
+    };
+
 #ifdef CET_DEBUG
     globals["DumpVtables"] = [this]
     {


### PR DESCRIPTION
- Added TrapInput script function to allow mods to show window with the mouse cursor displayed without opening the CET main overlay.
- Modified D3D12::DelayedSetTrapInputInImGui to properly handle multiple calls from different windows, including CET overlay.


https://github.com/user-attachments/assets/993aa2eb-78ef-42e8-945b-8a4427fb692d

