### PR TITLE
Enable Docking

### DIFF
--- a/src/d3d12/D3D12.cpp
+++ b/src/d3d12/D3D12.cpp
@@ -38,7 +38,8 @@ LRESULT D3D12::OnWndProc(HWND ahWnd, UINT auMsg, WPARAM awParam, LPARAM alParam)
 
         if (d3d12.m_trapInputInImGui) // TODO: look into io.WantCaptureMouse and io.WantCaptureKeyboard
         {
-            ImGui_ImplWin32_WndProcHandler(ahWnd, auMsg, awParam, alParam);
+            if (const LRESULT res = ImGui_ImplWin32_WndProcHandler(ahWnd, auMsg, awParam, alParam))
+                return res;
 
             // ignore mouse & keyboard events
             if ((auMsg >= WM_MOUSEFIRST && auMsg <= WM_MOUSELAST) || (auMsg >= WM_KEYFIRST && auMsg <= WM_KEYLAST))

--- a/src/d3d12/D3D12.cpp
+++ b/src/d3d12/D3D12.cpp
@@ -30,9 +30,6 @@ LRESULT D3D12::OnWndProc(HWND ahWnd, UINT auMsg, WPARAM awParam, LPARAM alParam)
 
     if (d3d12.IsInitialized())
     {
-        if (const auto res = ImGui_ImplWin32_WndProcHandler(ahWnd, auMsg, awParam, alParam))
-            return res;
-
         if (d3d12.m_delayedTrapInput)
         {
             d3d12.SetTrapInputInImGui(m_delayedTrapInputState);
@@ -41,6 +38,8 @@ LRESULT D3D12::OnWndProc(HWND ahWnd, UINT auMsg, WPARAM awParam, LPARAM alParam)
 
         if (d3d12.m_trapInputInImGui) // TODO: look into io.WantCaptureMouse and io.WantCaptureKeyboard
         {
+            ImGui_ImplWin32_WndProcHandler(ahWnd, auMsg, awParam, alParam);
+
             // ignore mouse & keyboard events
             if ((auMsg >= WM_MOUSEFIRST && auMsg <= WM_MOUSELAST) || (auMsg >= WM_KEYFIRST && auMsg <= WM_KEYLAST))
                 return 1;

--- a/src/d3d12/D3D12_Functions.cpp
+++ b/src/d3d12/D3D12_Functions.cpp
@@ -313,7 +313,7 @@ bool D3D12::InitializeImGui(size_t aBuffersCounts)
     ImGui::GetStyle() = m_styleReference;
     ImGui::GetStyle().ScaleAllSizes(scaleFromReference);
 
-    ImGui::GetIO().ConfigFlags |= ImGuiConfigFlags_NoMouseCursorChange; // Do not modify cursor from ImGui backend
+    ImGui::GetIO().ConfigFlags |= ImGuiConfigFlags_DockingEnable;
 
     if (!ImGui_ImplWin32_Init(m_window.GetWindow()))
     {

--- a/src/overlay/Overlay.cpp
+++ b/src/overlay/Overlay.cpp
@@ -61,6 +61,8 @@ void Overlay::Update()
     if (!m_initialized)
         return;
 
+    ImGui::DockSpaceOverViewport(0, ImGui::GetMainViewport(), ImGuiDockNodeFlags_PassthruCentralNode);
+    
     if (m_toggled)
     {
         if (m_bindings.FirstTimeSetup())
@@ -215,8 +217,6 @@ void Overlay::Update()
 
     if (!m_enabled)
         return;
-
-    ImGui::DockSpaceOverViewport(0, ImGui::GetMainViewport(), ImGuiDockNodeFlags_PassthruCentralNode);
 
     const auto [width, height] = CET::Get().GetD3D12().GetResolution();
     const auto heightLimit = 2 * ImGui::GetFrameHeight() + 2 * ImGui::GetStyle().WindowPadding.y;

--- a/src/overlay/Overlay.cpp
+++ b/src/overlay/Overlay.cpp
@@ -61,8 +61,6 @@ void Overlay::Update()
     if (!m_initialized)
         return;
 
-    ImGui::DockSpaceOverViewport(0, ImGui::GetMainViewport(), ImGuiDockNodeFlags_PassthruCentralNode);
-
     if (m_toggled)
     {
         if (m_bindings.FirstTimeSetup())
@@ -217,6 +215,8 @@ void Overlay::Update()
 
     if (!m_enabled)
         return;
+
+    ImGui::DockSpaceOverViewport(0, ImGui::GetMainViewport(), ImGuiDockNodeFlags_PassthruCentralNode);
 
     const auto [width, height] = CET::Get().GetD3D12().GetResolution();
     const auto heightLimit = 2 * ImGui::GetFrameHeight() + 2 * ImGui::GetStyle().WindowPadding.y;

--- a/src/overlay/Overlay.cpp
+++ b/src/overlay/Overlay.cpp
@@ -61,6 +61,8 @@ void Overlay::Update()
     if (!m_initialized)
         return;
 
+    ImGui::DockSpaceOverViewport(0, ImGui::GetMainViewport(), ImGuiDockNodeFlags_PassthruCentralNode);
+
     if (m_toggled)
     {
         if (m_bindings.FirstTimeSetup())

--- a/src/sol_imgui/sol_imgui.h
+++ b/src/sol_imgui/sol_imgui.h
@@ -2973,6 +2973,7 @@ inline void InitEnums(sol::table luaGlobals)
         ImGuiWindowFlags_NoFocusOnAppearing, "NoBringToFrontOnFocus", ImGuiWindowFlags_NoBringToFrontOnFocus, "AlwaysVerticalScrollbar", ImGuiWindowFlags_AlwaysVerticalScrollbar,
         "AlwaysHorizontalScrollbar", ImGuiWindowFlags_AlwaysHorizontalScrollbar, "NoNavInputs", ImGuiWindowFlags_NoNavInputs, "NoNavFocus", ImGuiWindowFlags_NoNavFocus,
         "UnsavedDocument", ImGuiWindowFlags_UnsavedDocument, "NoNav", ImGuiWindowFlags_NoNav, "NoDecoration", ImGuiWindowFlags_NoDecoration, "NoInputs", ImGuiWindowFlags_NoInputs,
+        "NoDocking", ImGuiWindowFlags_NoDocking,
         // [Internal]
         "ChildWindow", ImGuiWindowFlags_ChildWindow, "Tooltip", ImGuiWindowFlags_Tooltip, "Popup", ImGuiWindowFlags_Popup, "Modal", ImGuiWindowFlags_Modal, "ChildMenu",
         ImGuiWindowFlags_ChildMenu,


### PR DESCRIPTION
# Enable Docking

Added:
* Docking and Docking Over Viewport (so windows can be docked to the viewport, not just other windows) 

Changed:
* ImGui now only gets passed the input when the overlay is open, the trap continues to consume all events after

Removed:
* No Mouse Course Change Flag which was causing incorrect mouse cursor state